### PR TITLE
Starting point for the DO configuration using Terraform 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 **/.terraform/*
 
 # .tfstate files
-*.tfstate
-*.tfstate.*
+#*.tfstate.*
+#*.tfstate
 
 # Crash log files
 crash.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 **/.terraform/*
 
 # .tfstate files
-#*.tfstate.*
-#*.tfstate
+*.tfstate.*
+*.tfstate
 
 # Crash log files
 crash.log

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/digitalocean/digitalocean" {
+  version     = "2.31.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:pfVWDHu3mBfo6/bSUXb66V8MnER5VJkdMUCsTbQy0Qc=",
+    "zh:1eaf43da5ba5cf0ad4579fc084866ac70d2f597250218db8e573ee6045b51879",
+    "zh:1fd974e38833443c7d2c4b6e56cbb83d5ac086858c6dcaa9be79a85cb4106984",
+    "zh:2143630f078f844e4006b546a6f43653308d00ef5a5afa51e5605d290d8f9270",
+    "zh:2ea11260f4aada058d978abf6371fb0016f1e5ad650583b1842733dde1a1c6ed",
+    "zh:2f77f4e385db98bfc26b7c43c52ab4bcda2221191404726d0b76939d96eeb254",
+    "zh:3262dbbbfa33f3e0e775f4e2a0d995f942a0606df3f92f3db58d3a2b828eb4c1",
+    "zh:39cc06925c2141b7fccd729e2d98d84194af4b6603849c8eeef9e16c6e473507",
+    "zh:4a401f612caef535905c793bad2c7d7e54ff385f0cd5fd352bad648468647a80",
+    "zh:50d59d672d7c9e7e7eb4228eb6bdbe8dae8e8dac106c8c5effced15bfa65300a",
+    "zh:7760d8ec7af57b95a115496698fed14676b584d85465459d50e21c37add4b3e1",
+    "zh:8bc9f5b3b74bc084724b7342fff44e93a4f552acf4cf5878e53bd4f327a6362a",
+    "zh:9abf8e64705d57e29129472ac937531154dc8eec83a3a4848fbaaee87a656276",
+    "zh:a3d7ac59fdeb704fcb0a8c354e0ae611b377637fb76d88f89e9dc9be0e3c3945",
+    "zh:c71fa05665304954f62d7e2632634f29e8ab7a0a228698c6605c951dfb843a51",
+    "zh:efd7b29d8f65a97cb65823948b878f0cd3e42703c2ed71e2fe39769a1a9b9faa",
+    "zh:fb04df7c68ee96b110b5e72da7a776f01007ec919ecff914fd84ae6cb8e3ddad",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ Using `tf.vars` file
 `token = XXXXXX`
 
 ### Pending / In progress
-- Create`digitalocean_vpc` resources and use attributes on `droplet` resources (DONE)
+- Create `digitalocean_vpc` resources and use attributes on `droplet` resources (DONE)
 - Create `resource`  with a `SSH` public key using [this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) resource with a generated SSH local key (DONE)
-- It will be at least two or three ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) --ª (IN PROGRESS)
-- Include `tags`, `user_data`, `droplet_agent`, `ssh_keys` and `vpc_uuid` argument for the creation of the `droplets` (The third one) (TO BE DONE)
+- It will be at least two or three ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) --- (DONE IT USING FIXED LIST)
+- Include a way to dynamically generate the list using the data from `data digitalocean_regions`
+- Include `tags`, `user_data`, `droplet_agent`, `ssh_keys` and `vpc_uuid` argument for the creation of the `droplets` (The third one) (TAGS DONE, STILL USER DATA MISSING)
 - Review the best way to pass `image` and `size` for `droplet`. For sizes, images and other values we have this [references](https://slugs.do-api.dev/) to check later (TO BE DONE)
 - Some `outputs` attributes from `data data digitalocean_region` has been included to understand how to use the `filters` on the `data digitalocean_regions` resource. (NEW OUTPUT FOR THE DATA RESOURCES REGIONS HAS BEEN CREATED)
-- Modify the `name` expression for the `droplet` resource using probably tags or other variables to demonstrate an example 
+- Modify the `name` expression for the `droplet` resource using probably tags or other variables to demonstrate an example (DONE)
+- Create the code to create dinamically the tags instead individual blocks for each  `digitalocean_tag` resource. Map variable and `for_each` meta argument. (TO BE DONE)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# digital_ocean
-Repo to deploy DO infra 
+## Testing Digital Ocean for small projects
+### Provider
+The provider can be authenticated using personal token as a `env` variable or with the use of `tfvars` file and letting `.gitignore` file exclude the same to avoid any secret / API Key leak
+
+In order to allow terraform commands use the file, the following command should be executed
+```
+terraform plan -var-file="input.tfvars
+```
+
+
+#### Options
+Using `env` variable
+`export DO_PAT="your_personal_access_token"`
+Using `tf.vars` file
+`token = XXXXXX`
+
+### Pending / In progress
+- Create`digitalocean_vpc` resources and use attributes on `droplet` resources (DONE)
+- Create `resource`  with a `SSH` public key using [this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) resource with a generated SSH local key (DONE)
+- It will be at least two or three ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) --ª (IN PROGRESS)
+- Include `tags`, `user_data`, `droplet_agent`, `ssh_keys` and `vpc_uuid` argument for the creation of the `droplets` (The third one) (TO BE DONE)
+- Review the best way to pass `image` and `size` for `droplet`. For sizes, images and other values we have this [references](https://slugs.do-api.dev/) to check later (TO BE DONE)
+- Some `outputs` attributes from `data data digitalocean_region` has been included to understand how to use the `filters` on the `data digitalocean_regions` resource. (NEW OUTPUT FOR THE DATA RESOURCES REGIONS HAS BEEN CREATED)
+- Modify the `name` expression for the `droplet` resource using probably tags or other variables to demonstrate an example 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 ## Testing Digital Ocean for small projects
+## Version 1.0
 ### Provider
 The provider can be authenticated using personal token as a `env` variable or with the use of `tfvars` file and letting `.gitignore` file exclude the same to avoid any secret / API Key leak
 
 In order to allow terraform commands use the file, the following command should be executed
 ```
-terraform plan -var-file="input.tfvars
+terraform plan -var-file="input.tfvars"
+```
+To apply this infra you must choose the type of `droplet` based on the model. I strongly suggest ran this command 
+```
+terraform apply -var-file="input.tfvars" --auto-approve
 ```
 
 
@@ -24,3 +29,6 @@ Using `tf.vars` file
 - Some `outputs` attributes from `data data digitalocean_region` has been included to understand how to use the `filters` on the `data digitalocean_regions` resource. (NEW OUTPUT FOR THE DATA RESOURCES REGIONS HAS BEEN CREATED)
 - Modify the `name` expression for the `droplet` resource using probably tags or other variables to demonstrate an example (DONE)
 - Create the code to create dinamically the tags instead individual blocks for each  `digitalocean_tag` resource. Map variable and `for_each` meta argument. (TO BE DONE)
+
+### Note
+Still some work to do, let's release this first version. 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Using `tf.vars` file
 ### Pending / In progress
 - Create `digitalocean_vpc` resources and use attributes on `droplet` resources (DONE)
 - Create `resource`  with a `SSH` public key using [this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) resource with a generated SSH local key (DONE)
-- It will be at least two or three ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) --- (DONE IT USING FIXED LIST)
-- Include a way to dynamically generate the list using the data from `data digitalocean_regions`
+- It will be at least two or four ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) --- (DONE IT USING FIXED LIST)
+- Include a way to dynamically generate the list using the data from `data digitalocean_regions` (DONE)
 - Include `tags`, `user_data`, `droplet_agent`, `ssh_keys` and `vpc_uuid` argument for the creation of the `droplets` (The third one) (TAGS DONE, STILL USER DATA MISSING)
 - Review the best way to pass `image` and `size` for `droplet`. For sizes, images and other values we have this [references](https://slugs.do-api.dev/) to check later (TO BE DONE)
 - Some `outputs` attributes from `data data digitalocean_region` has been included to understand how to use the `filters` on the `data digitalocean_regions` resource. (NEW OUTPUT FOR THE DATA RESOURCES REGIONS HAS BEEN CREATED)

--- a/data.tf
+++ b/data.tf
@@ -1,4 +1,5 @@
 #For future uses, I should find a way to use this as a source for the regions to be deployed
+#Also I should use this for the argument of the meta argument count   = length(data.digitalocean_regions.available-with-features.regions)
 data "digitalocean_regions" "available-with-features" {
   filter {
     key    = "available"
@@ -19,29 +20,4 @@ data "digitalocean_regions" "available-with-features" {
     match_by = "substring"
   }
 }
-
-# output "test" {
-#   value = data.digitalocean_regions.available-with-features.regions
-# }
-
-# #Testing the data singular data resource
-# data "digitalocean_region" "sfo2" {
-#   slug = "sfo2"
-# }
-
-# output "region_name" {
-#   value = data.digitalocean_region.sfo2.name
-# }
-
-# output "region_status" {
-#   value = data.digitalocean_region.sfo2.available
-# }
-
-# output "region_sizes" {
-#   value = data.digitalocean_region.sfo2.sizes
-# }
-
-# output "region_features" {
-#   value = data.digitalocean_region.sfo2.features
-# }
 

--- a/data.tf
+++ b/data.tf
@@ -8,8 +8,8 @@ data "digitalocean_regions" "available-with-features" {
     values = ["backups"]
   }
   filter {
-    key = "sizes"
-    values = ["s-1vcpu"]
+    key      = "sizes"
+    values   = ["s-1vcpu"]
     match_by = "substring"
   }
 }

--- a/data.tf
+++ b/data.tf
@@ -12,25 +12,35 @@ data "digitalocean_regions" "available-with-features" {
     values   = ["s-1vcpu"]
     match_by = "substring"
   }
+  filter {
+    key      = "slug"
+    values   = ["ny"]
+    match_by = "substring"
+  }
 }
 
-#Testing the data singular data resource
-data "digitalocean_region" "sfo2" {
-  slug = "sfo2"
+output "test" {
+  value = data.digitalocean_regions.available-with-features.regions
 }
 
-output "region_name" {
-  value = data.digitalocean_region.sfo2.name
-}
+# #Testing the data singular data resource
+# data "digitalocean_region" "sfo2" {
+#   slug = "sfo2"
+# }
 
-output "region_status" {
-  value = data.digitalocean_region.sfo2.available
-}
+# output "region_name" {
+#   value = data.digitalocean_region.sfo2.name
+# }
 
-output "region_sizes" {
-  value = data.digitalocean_region.sfo2.sizes
-}
+# output "region_status" {
+#   value = data.digitalocean_region.sfo2.available
+# }
 
-output "region_features" {
-  value = data.digitalocean_region.sfo2.features
-}
+# output "region_sizes" {
+#   value = data.digitalocean_region.sfo2.sizes
+# }
+
+# output "region_features" {
+#   value = data.digitalocean_region.sfo2.features
+# }
+

--- a/data.tf
+++ b/data.tf
@@ -19,9 +19,9 @@ data "digitalocean_regions" "available-with-features" {
   }
 }
 
-output "test" {
-  value = data.digitalocean_regions.available-with-features.regions
-}
+# output "test" {
+#   value = data.digitalocean_regions.available-with-features.regions
+# }
 
 # #Testing the data singular data resource
 # data "digitalocean_region" "sfo2" {

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,36 @@
+data "digitalocean_regions" "available-with-features" {
+  filter {
+    key    = "available"
+    values = ["true"]
+  }
+  filter {
+    key    = "features"
+    values = ["backups"]
+  }
+  filter {
+    key = "sizes"
+    values = ["s-1vcpu"]
+    match_by = "substring"
+  }
+}
+
+#Testing the data singular data resource
+data "digitalocean_region" "sfo2" {
+  slug = "sfo2"
+}
+
+output "region_name" {
+  value = data.digitalocean_region.sfo2.name
+}
+
+output "region_status" {
+  value = data.digitalocean_region.sfo2.available
+}
+
+output "region_sizes" {
+  value = data.digitalocean_region.sfo2.sizes
+}
+
+output "region_features" {
+  value = data.digitalocean_region.sfo2.features
+}

--- a/data.tf
+++ b/data.tf
@@ -1,3 +1,4 @@
+#For future uses, I should find a way to use this as a source for the regions to be deployed
 data "digitalocean_regions" "available-with-features" {
   filter {
     key    = "available"

--- a/locals.tf
+++ b/locals.tf
@@ -1,3 +1,4 @@
 locals {
-  dynamic-regions = [for region_attribute in data.digitalocean_regions.available-with-features.regions: region_attribute.slug]
+  dynamic-regions = [for region_attribute in data.digitalocean_regions.available-with-features.regions : region_attribute.slug]
+  ip_nets         = cidrsubnets(var.vpc-cidr, 4, 4)
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,3 @@
+locals {
+  dynamic-regions = [for region_attribute in data.digitalocean_regions.available-with-features.regions: region_attribute.slug]
+}

--- a/main.tf
+++ b/main.tf
@@ -1,33 +1,33 @@
 #Without using any variable 
-resource "digitalocean_droplet" "web-app" {
-  image  = "ubuntu-20-04-x64"
-  name   = "webserver"
-  region = "nyc2"
-  size   = "s-1vcpu-1gb"
-}
+# resource "digitalocean_droplet" "web-app" {
+#   image  = "ubuntu-20-04-x64"
+#   name   = "webserver"
+#   region = "nyc1"
+#   size   = "s-1vcpu-1gb"
+# }
 
-#Using variables 
-resource "digitalocean_droplet" "web-app-exportable" {
-  image  = var.image
-  name   = var.name
-  region = var.region
-  size   = var.droplet_size
-}
+# #Using variables 
+# resource "digitalocean_droplet" "web-app-exportable" {
+#   image  = var.image
+#   name   = var.name
+#   region = var.region
+#   size   = var.droplet_size
+# }
 
 #Using fixed list of regions too deploy the droplets
 
-resource "digitalocean_droplet" "web-app-smart" {
-  count    = length(var.regions)
-  image    = var.image
-  name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
-  region   = var.regions[count.index]
-  size     = var.droplet_size
-  vpc_uuid = digitalocean_vpc.acme_vpc.id
-  ssh_keys = [digitalocean_ssh_key.default.fingerprint]
-  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
-}
+# resource "digitalocean_droplet" "web-app-smart" {
+#   count    = length(var.regions)
+#   image    = var.image
+#   name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+#   region   = var.regions[count.index]
+#   size     = var.droplet_size
+#   vpc_uuid = digitalocean_vpc.acme-vpc-single-region.id
+#   ssh_keys = [digitalocean_ssh_key.default.fingerprint]
+#   tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
+# }
 
-#Using dynamic list with specific features for the regions
+# #Using dynamic list with specific features for the regions
 
 resource "digitalocean_droplet" "web-app-features" {
   count    = length(local.dynamic-regions)
@@ -35,7 +35,7 @@ resource "digitalocean_droplet" "web-app-features" {
   name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
   region   = local.dynamic-regions[count.index]
   size     = var.droplet_size
-  vpc_uuid = digitalocean_vpc.acme_vpc.id
+  vpc_uuid = digitalocean_vpc.acme-vpc-multi-region[count.index].id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]
   tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
 }

--- a/main.tf
+++ b/main.tf
@@ -17,17 +17,31 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  count    = length(data.digitalocean_regions.available-with-features.regions)
+  count    = length(var.regions)
   image    = var.image
   name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
   region   = var.regions[count.index]
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]
+  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
 }
 
 #Creating the SSH resource for the droplet
 resource "digitalocean_ssh_key" "default" {
   name       = "ssh-key-${var.customer-name}-${var.project-name}"
   public_key = file("/home/miguel/.ssh/github_key.pub")
+}
+
+#Tags for the droplet
+resource "digitalocean_tag" "poc" {
+  name = "POC"
+}
+
+resource "digitalocean_tag" "webserver" {
+  name = "webserver"
+}
+
+resource "digitalocean_tag" "company" {
+  name = "ACME"
 }

--- a/main.tf
+++ b/main.tf
@@ -23,4 +23,11 @@ resource "digitalocean_droplet" "web-app-smart" {
   region   = count.index
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
+  ssh_keys = [digitalocean_ssh_key.default.fingerprint]
+}
+
+#Creating the SSH resource for the droplet
+resource "digitalocean_ssh_key" "default" {
+  name       = "ssh-key-${var.customer-name}-${var.project-name}"
+  public_key = file("/home/miguel/.ssh/github_key.pub")
 }

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,24 @@
+#Without using any variable 
 resource "digitalocean_droplet" "web-app" {
   image  = "ubuntu-20-04-x64"
   name   = "webserver"
   region = "nyc2"
   size   = "s-1vcpu-1gb"
+}
+
+#Using variables 
+resource "digitalocean_droplet" "web-app-exportable" {
+  image  = var.image
+  name   = var.name
+  region = var.region
+  size   = var.droplet_size
+}
+
+#Using data resources with different filters
+#Using variables 
+resource "digitalocean_droplet" "web-app-smart" {
+  image  = var.image
+  name   = var.name
+  region = var.region
+  size   = data.digitalocean_regions.available-with-features.regions.sizes
 }

--- a/main.tf
+++ b/main.tf
@@ -1,31 +1,31 @@
 #Without using any variable 
-# resource "digitalocean_droplet" "web-app" {
-#   image  = "ubuntu-20-04-x64"
-#   name   = "webserver"
-#   region = "nyc1"
-#   size   = "s-1vcpu-1gb"
-# }
+resource "digitalocean_droplet" "web-app" {
+  image  = "ubuntu-20-04-x64"
+  name   = "webserver"
+  region = "nyc1"
+  size   = "s-1vcpu-1gb"
+}
 
-# #Using variables 
-# resource "digitalocean_droplet" "web-app-exportable" {
-#   image  = var.image
-#   name   = var.name
-#   region = var.region
-#   size   = var.droplet_size
-# }
+#Using variables 
+resource "digitalocean_droplet" "web-app-exportable" {
+  image  = var.image
+  name   = var.name
+  region = var.region
+  size   = var.droplet_size
+}
 
 #Using fixed list of regions too deploy the droplets
 
-# resource "digitalocean_droplet" "web-app-smart" {
-#   count    = length(var.regions)
-#   image    = var.image
-#   name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
-#   region   = var.regions[count.index]
-#   size     = var.droplet_size
-#   vpc_uuid = digitalocean_vpc.acme-vpc-single-region.id
-#   ssh_keys = [digitalocean_ssh_key.default.fingerprint]
-#   tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
-# }
+resource "digitalocean_droplet" "web-app-smart" {
+  count    = length(var.regions)
+  image    = var.image
+  name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+  region   = var.regions[count.index]
+  size     = var.droplet_size
+  vpc_uuid = digitalocean_vpc.acme-vpc-single-region.id
+  ssh_keys = [digitalocean_ssh_key.default.fingerprint]
+  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
+}
 
 # #Using dynamic list with specific features for the regions
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,6 @@
+resource "digitalocean_droplet" "web-app" {
+  image  = "ubuntu-20-04-x64"
+  name   = "webserver"
+  region = "nyc2"
+  size   = "s-1vcpu-1gb"
+}

--- a/main.tf
+++ b/main.tf
@@ -14,13 +14,26 @@ resource "digitalocean_droplet" "web-app-exportable" {
   size   = var.droplet_size
 }
 
-#Using data resources with different filters
+#Using fixed list of regions too deploy the droplets
 
 resource "digitalocean_droplet" "web-app-smart" {
   count    = length(var.regions)
   image    = var.image
   name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
   region   = var.regions[count.index]
+  size     = var.droplet_size
+  vpc_uuid = digitalocean_vpc.acme_vpc.id
+  ssh_keys = [digitalocean_ssh_key.default.fingerprint]
+  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
+}
+
+#Using dynamic list with specific features for the regions
+
+resource "digitalocean_droplet" "web-app-features" {
+  count    = length(local.dynamic-regions)
+  image    = var.image
+  name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+  region   = local.dynamic-regions[count.index]
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  for_each = data.digitalocean_regions.available-with-features
+  for_each = data.digitalocean_regions.available-with-features.region.slug
   image    = var.image
   name     = var.name
-  region   = var.region
+  region   = each.value
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
 }

--- a/main.tf
+++ b/main.tf
@@ -18,9 +18,9 @@ resource "digitalocean_droplet" "web-app-exportable" {
 
 resource "digitalocean_droplet" "web-app-smart" {
   for_each = data.digitalocean_regions.available-with-features
-  image  = var.image
-  name   = var.name
-  region = var.region
-  size   = var.droplet_size
+  image    = var.image
+  name     = var.name
+  region   = var.region
+  size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
 }

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  for_each = data.digitalocean_regions.available-with-features
+  for_each = data.digitalocean_regions.available-with-features.regions
   image    = var.image
   name     = var.name
-  region   = each.value
+  #region   = each.value
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  count = data.digitalocean_regions.available-with-features.regions
+  for_each = data.digitalocean_regions.available-with-features
   image    = var.image
   name     = var.name
-  region   = count.index
+  region   = each.value
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  for_each = data.digitalocean_regions.available-with-features.region.slug
+  count = data.digitalocean_regions.available-with-features.regions
   image    = var.image
   name     = var.name
-  region   = each.value
+  region   = count.index
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
 }

--- a/main.tf
+++ b/main.tf
@@ -15,10 +15,12 @@ resource "digitalocean_droplet" "web-app-exportable" {
 }
 
 #Using data resources with different filters
-#Using variables 
+
 resource "digitalocean_droplet" "web-app-smart" {
+  for_each = data.digitalocean_regions.available-with-features
   image  = var.image
   name   = var.name
   region = var.region
-  size   = data.digitalocean_regions.available-with-features.regions.sizes
+  size   = var.droplet_size
+  vpc_uuid = digitalocean_vpc.acme_vpc.id
 }

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ resource "digitalocean_droplet" "web-app-exportable" {
 #Using data resources with different filters
 
 resource "digitalocean_droplet" "web-app-smart" {
-  for_each = data.digitalocean_regions.available-with-features.regions
+  count    = length(data.digitalocean_regions.available-with-features.regions)
   image    = var.image
-  name     = var.name
-  #region   = each.value
+  name     = "droplet-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+  region   = var.regions[count.index]
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme_vpc.id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "digitalocean_droplet" "web-app-features" {
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.acme-vpc-multi-region[count.index].id
   ssh_keys = [digitalocean_ssh_key.default.fingerprint]
-  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id , digitalocean_tag.poc.id ]
+  tags     = [digitalocean_tag.company.id, digitalocean_tag.webserver.id, digitalocean_tag.poc.id]
 }
 
 #Creating the SSH resource for the droplet

--- a/network.tf
+++ b/network.tf
@@ -5,8 +5,7 @@
 # }
 
 resource "digitalocean_vpc" "acme-vpc-multi-region" {
-  count = length(local.dynamic-regions)
-  name     = "vpc-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
-  region   = local.dynamic-regions[count.index]
-  ip_range = var.vpc-cidr
+  count  = length(local.dynamic-regions)
+  name   = "vpc-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+  region = local.dynamic-regions[count.index]
 }

--- a/network.tf
+++ b/network.tf
@@ -1,5 +1,5 @@
 resource "digitalocean_vpc" "acme_vpc" {
-  name     = "vpc-${var.customer-name}-${var.project-name}"
+  name     = "vpc-${var.customer-name}-${var.project-name}-${var.deployed-by}"
   region   = var.region
   ip_range = var.vpc-cidr
 }

--- a/network.tf
+++ b/network.tf
@@ -1,5 +1,12 @@
-resource "digitalocean_vpc" "acme_vpc" {
-  name     = "vpc-${var.customer-name}-${var.project-name}-${var.deployed-by}"
-  region   = var.region
+# resource "digitalocean_vpc" "acme-vpc-single-region" {
+#   name     = "vpc-${var.customer-name}-${var.project-name}-${var.deployed-by}"
+#   region   = var.region
+#   ip_range = var.vpc-cidr
+# }
+
+resource "digitalocean_vpc" "acme-vpc-multi-region" {
+  count = length(local.dynamic-regions)
+  name     = "vpc-${var.customer-name}-${var.project-name}-${count.index}-${var.deployed-by}"
+  region   = local.dynamic-regions[count.index]
   ip_range = var.vpc-cidr
 }

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,5 @@
+resource "digitalocean_vpc" "acme_vpc" {
+  name     = "vpc-${var.customer-name}-${var.project-name}"
+  region   = var.region
+  ip_range = var.vpc-cidr
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,28 @@
+output "testdynamic-regions" {
+  value = local.dynamic-regions
+}
+
+# output "test" {
+#   value = data.digitalocean_regions.available-with-features.regions
+# }
+
+# #Testing the data singular data resource
+# data "digitalocean_region" "sfo2" {
+#   slug = "sfo2"
+# }
+
+# output "region_name" {
+#   value = data.digitalocean_region.sfo2.name
+# }
+
+# output "region_status" {
+#   value = data.digitalocean_region.sfo2.available
+# }
+
+# output "region_sizes" {
+#   value = data.digitalocean_region.sfo2.sizes
+# }
+
+# output "region_features" {
+#   value = data.digitalocean_region.sfo2.features
+# }

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,22 @@
+#Variable for Digital Ocean API Token
+variable "do_token" {}
+
+variable "image" {
+  default     = "ubuntu-20-04-x64"
+  description = "String for Ubuntu 20.04"
+}
+
+variable "name" {
+  default     = "webserver"
+  description = "value for web server"
+}
+
+variable "region" {
+  default     = "nyc2"
+  description = "NYC Region"
+}
+
+variable "droplet_size" {
+  default     = "s-1vcpu-1gb"
+  description = "size of the server"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "name" {
 }
 
 variable "region" {
-  default     = "nyc2"
+  default     = "nyc1"
   description = "NYC Region"
 }
 
@@ -38,7 +38,7 @@ variable "project-name" {
 }
 
 variable "vpc-cidr" {
-  default     = "10.10.10.0/24"
+  default     = "10.108.16.0/20"
   description = "CIDR for the VPC"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -20,3 +20,13 @@ variable "droplet_size" {
   default     = "s-1vcpu-1gb"
   description = "size of the server"
 }
+
+variable "customer-name" {
+  default     = "ACME"
+  description = "Name of the customer"
+}
+
+variable "project-name" {
+  default     = "web-app"
+  description = "Name of the application"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "project-name" {
 }
 
 variable "vpc-cidr" {
-  default     = "10.108.16.0/20"
+  default     = "10.108.16.0/16"
   description = "CIDR for the VPC"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -30,3 +30,8 @@ variable "project-name" {
   default     = "web-app"
   description = "Name of the application"
 }
+
+variable "vpc-cidr" {
+  default     = "10.10.10.0/24"
+  description = "CIDR for the VPC"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,9 @@ variable "region" {
 }
 
 variable "regions" {
-  default = ["nyc1", "nyc2"]
+  type        = list(any)
+  default     = ["nyc1", "nyc2"]
+  description = "Fixed list for regions"
 }
 
 variable "droplet_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,10 @@ variable "region" {
   description = "NYC Region"
 }
 
+variable "regions" {
+  default = ["nyc1", "nyc2"]
+}
+
 variable "droplet_size" {
   default     = "s-1vcpu-1gb"
   description = "size of the server"
@@ -34,4 +38,9 @@ variable "project-name" {
 variable "vpc-cidr" {
   default     = "10.10.10.0/24"
   description = "CIDR for the VPC"
+}
+
+variable "deployed-by" {
+  default = "mv"
+  type    = string
 }


### PR DESCRIPTION
Added the main files for the configuration of the droplet in `Digital Ocean`
- `main.tf`
- `provider.tf` with a configuration block using a `token` argument with an empty variable
- `variables.tf` file
- `data.tf` file to attach `SSH` data resources keys for the deployment of the `droplet`

The use of the API key for DO provider is provided manually when the `terraform plan` is executed. 
Note: I would like to find a way to do it in a best way. `gitignore` file is excluding the `.tfvars` file, so I can include the value for the env variable to avoid write it every `terraform plan` execution
#### Options
Using `env` variable
`export DO_PAT="your_personal_access_token"`
Using `tf.vars` file
`token = XXXXXX`

### Pending / In progress
- Create`digitalocean_vpc` resources and use attributes on `droplet` resources
- Create `data` resource with a `SSH` public key using [this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/resources/ssh_key) resource with a generated SSH local key
- It will be at least two or three ways to create the `droplet` using the same `resource`. The latest will create several `droplets` using the results from `data digitalocean_regions` on multiple regions. [Check this](https://registry.terraform.io/providers/digitalocean/digitalocean/latest/docs/data-sources/regions) 
- Include `tags`, `user_data`, `droplet_agent`, `ssh_keys` and `vpc_uuid` argument for the creation of the `droplets` (The third one)
- Review the best way to pass `image` and `size` for `droplet`. For sizes, images and other values we have this [references](https://slugs.do-api.dev/) to check later 
- Some `outputs` attributes from `data data digitalocean_region` has been included to understand how to use the `filters` on the `data digitalocean_regions` resource. 
- Modify the `name` expression for the `droplet` resource using probably tags or other variables to demonstrate an example